### PR TITLE
Refactor canvas history paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react-icons": "^5.0.1"
   },
   "devDependencies": {
+    "@types/node": "^20.11.25",
     "@types/react": "^18.2.56",
     "@types/react-dom": "^18.2.19",
     "@typescript-eslint/eslint-plugin": "^7.0.2",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "classic-react-components": "^0.1.0",
     "jotai": "^2.6.5",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-icons": "^5.0.1"
   },
   "devDependencies": {
     "@types/react": "^18.2.56",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ dependencies:
     version: 5.0.1(react@18.2.0)
 
 devDependencies:
+  '@types/node':
+    specifier: ^20.11.25
+    version: 20.11.25
   '@types/react':
     specifier: ^18.2.56
     version: 18.2.58
@@ -63,7 +66,7 @@ devDependencies:
     version: 5.3.3
   vite:
     specifier: ^5.1.4
-    version: 5.1.4
+    version: 5.1.4(@types/node@20.11.25)
 
 packages:
 
@@ -776,6 +779,12 @@ packages:
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
     dev: true
 
+  /@types/node@20.11.25:
+    resolution: {integrity: sha512-TBHyJxk2b7HceLVGFcpAUjsa5zIdsPWlR6XHfyGzd0SFu+/NFgQgMAl96MSDZgQDvJAvV6BKsFOrt6zIL09JDw==}
+    dependencies:
+      undici-types: 5.26.5
+    dev: true
+
   /@types/prop-types@15.7.11:
     resolution: {integrity: sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==}
 
@@ -946,7 +955,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.23.3(@babel/core@7.23.9)
       '@types/babel__core': 7.20.5
       react-refresh: 0.14.0
-      vite: 5.1.4
+      vite: 5.1.4(@types/node@20.11.25)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -2343,6 +2352,10 @@ packages:
     hasBin: true
     dev: true
 
+  /undici-types@5.26.5:
+    resolution: {integrity: sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==}
+    dev: true
+
   /update-browserslist-db@1.0.13(browserslist@4.23.0):
     resolution: {integrity: sha512-xebP81SNcPuNpPP3uzeW1NYXxI3rxyJzF3pD6sH4jE7o/IX+WtSpwnVU+qIsDPyk0d3hmFQ7mjqc6AtV604hbg==}
     hasBin: true
@@ -2364,7 +2377,7 @@ packages:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
     dev: true
 
-  /vite@5.1.4:
+  /vite@5.1.4(@types/node@20.11.25):
     resolution: {integrity: sha512-n+MPqzq+d9nMVTKyewqw6kSt+R3CkvF9QAKY8obiQn8g1fwTscKxyfaYnC632HtBXAQGc1Yjomphwn1dtwGAHg==}
     engines: {node: ^18.0.0 || >=20.0.0}
     hasBin: true
@@ -2392,6 +2405,7 @@ packages:
       terser:
         optional: true
     dependencies:
+      '@types/node': 20.11.25
       esbuild: 0.19.12
       postcss: 8.4.35
       rollup: 4.12.0

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   react-dom:
     specifier: ^18.2.0
     version: 18.2.0(react@18.2.0)
+  react-icons:
+    specifier: ^5.0.1
+    version: 5.0.1(react@18.2.0)
 
 devDependencies:
   '@types/react':
@@ -2043,6 +2046,14 @@ packages:
       loose-envify: 1.4.0
       react: 18.2.0
       scheduler: 0.23.0
+    dev: false
+
+  /react-icons@5.0.1(react@18.2.0):
+    resolution: {integrity: sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==}
+    peerDependencies:
+      react: '*'
+    dependencies:
+      react: 18.2.0
     dev: false
 
   /react-refresh@0.14.0:

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import Canvas from './components/canvas'
+import CanvasActionContainer from './components/canvas-actions-container'
 import CanvasStyleContainer from './components/canvas-style-container'
 
 export default function App() {
    return (
       <div>
+         <CanvasActionContainer />
          <Canvas />
          <CanvasStyleContainer />
       </div>

--- a/src/components/canvas-actions-container.tsx
+++ b/src/components/canvas-actions-container.tsx
@@ -1,0 +1,17 @@
+import { FaRedo, FaUndo } from "react-icons/fa";
+
+export default function CanvasActionContainer(){
+    return (
+        <section className="canvas-action-container fixed bg-gray-500 px-4 py-2">
+            <div className="flex gap-4">
+
+            <button title="Undo -- CtrlZ" className={'text-white'}>
+                <FaUndo />
+            </button>
+            <button title="Redo -- Ctrl Shift Z" className={'text-white'}>
+                <FaRedo />
+            </button>
+            </div>
+        </section>
+    )
+}

--- a/src/components/canvas-actions-container.tsx
+++ b/src/components/canvas-actions-container.tsx
@@ -1,17 +1,30 @@
-import { FaRedo, FaUndo } from "react-icons/fa";
+import { FaRedo, FaUndo } from 'react-icons/fa'
+import { useCanvasAtomValue, useCanvasHistoryIndex } from '../atom/canvas.atom'
 
-export default function CanvasActionContainer(){
-    return (
-        <section className="canvas-action-container fixed bg-gray-500 px-4 py-2">
-            <div className="flex gap-4">
+export default function CanvasActionContainer() {
+   const { redo, undo, history_index } = useCanvasHistoryIndex()
+   const { canvas_path_histories } = useCanvasAtomValue()
 
-            <button title="Undo -- CtrlZ" className={'text-white'}>
-                <FaUndo />
+   return (
+      <section className='canvas-action-container fixed bg-gray-500 px-4 py-2'>
+         <div className='flex gap-4'>
+            <button
+               title='Undo -- CtrlZ'
+               className={'text-white disabled:text-gray-300 cursor-pointer disabled:cursor-not-allowed'}
+               onClick={undo}
+               disabled={history_index == -1}
+            >
+               <FaUndo />
             </button>
-            <button title="Redo -- Ctrl Shift Z" className={'text-white'}>
-                <FaRedo />
+            <button
+               title='Redo -- Ctrl Shift Z'
+               className={'text-white disabled:text-gray-300 cursor-pointer disabled:cursor-not-allowed'}
+               onClick={redo}
+               disabled={history_index == canvas_path_histories.length - 1}
+            >
+               <FaRedo />
             </button>
-            </div>
-        </section>
-    )
+         </div>
+      </section>
+   )
 }

--- a/src/hooks/use-canvas-history.tsx
+++ b/src/hooks/use-canvas-history.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useEventListener } from './use-event-listener'
 import useSyncedRef from './use-synced-ref'
 import { useCanvasAtomValue, useCanvasHistoryIndex } from '../atom/canvas.atom'
@@ -9,6 +9,7 @@ export default function useCanvasHistory() {
    const [pressed_keys, setPressedKeys] = useState<string[]>([])
    const [clonedCanvasPath, setClonedCanvasPath] = useState(canvas_path_histories)
    const canvasPathsRef = useSyncedRef(canvas_path_histories)
+   const keyup_timer_id = useRef<NodeJS.Timeout>()
 
    const handleKeyDown = (e: KeyboardEvent) => {
       if (ALLOWED_KEYS.includes(e.key)) {
@@ -22,7 +23,10 @@ export default function useCanvasHistory() {
    }
 
    const handleKeyUp = (_e: KeyboardEvent) => {
-      setTimeout(() => {
+      if (keyup_timer_id.current) {
+         clearTimeout(keyup_timer_id.current)
+      }
+      keyup_timer_id.current = setTimeout(() => {
          setPressedKeys((keys) => {
             keys.pop()
             return [...keys]

--- a/src/hooks/use-canvas-history.tsx
+++ b/src/hooks/use-canvas-history.tsx
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+import { useEventListener } from './use-event-listener'
+import useSyncedRef from './use-synced-ref'
+
+export default function useCanvasHistory<T>({ canvasPaths }: { canvasPaths: T[] }) {
+   const [history_index, setHistoryIndex] = useState(canvasPaths.length - 1)
+   const [pressed_keys, setPressedKeys] = useState<string[]>([])
+   const [clonedCanvasPath, setClonedCanvasPath] = useState(canvasPaths)
+   const canvasPathsRef = useSyncedRef(canvasPaths)
+
+   const handleKeyDown = (e: KeyboardEvent) => {
+      if (ALLOWED_KEYS.includes(e.key)) {
+         setPressedKeys((keys) => {
+            if (keys.length < 3 && !keys.includes(e.key)) {
+               return [...keys, e.key]
+            }
+            return keys
+         })
+      }
+   }
+
+   const handleKeyUp = (_e: KeyboardEvent) => {
+      setTimeout(() => {
+         setPressedKeys((keys) => {
+            keys.pop()
+            return [...keys]
+         })
+      }, 0)
+   }
+
+   const clearPressedKeys = () => setPressedKeys([])
+
+   useEventListener(window, 'keydown', handleKeyDown)
+   useEventListener(window, 'keyup', handleKeyUp)
+
+   useEventListener(window, 'blur', clearPressedKeys)
+   useEventListener(window, 'focus', clearPressedKeys)
+
+   useEffect(() => {
+      // undo
+      if (pressed_keys.length == 2 && pressed_keys[0] == 'Control' && pressed_keys[1] == 'z') {
+         setHistoryIndex((i) => (i > -1 ? i - 1 : i))
+      }
+
+      // redo
+      if (
+         pressed_keys.length == 3 &&
+         pressed_keys[0] == 'Control' &&
+         pressed_keys[1] == 'Shift' &&
+         pressed_keys[2] == 'Z'
+      ) {
+         setHistoryIndex((i) => {
+            return i < canvasPaths.length - 1 ? i + 1 : i
+         })
+      }
+   }, [pressed_keys])
+
+   useEffect(() => {
+      setClonedCanvasPath(() => {
+         const arr = canvasPathsRef.current.slice(0, history_index + 1)
+         return arr
+      })
+   }, [history_index])
+
+   useEffect(() => {
+      setHistoryIndex(canvasPaths.length - 1)
+   }, [canvasPaths])
+
+   return { clonedCanvasPath }
+}
+
+const ALLOWED_KEYS = ['Control', 'Shift', 'z', 'Z']

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+// import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
 import './index.css'

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import App from './App.tsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
-   <React.StrictMode>
-      <App />
-   </React.StrictMode>
+   // <React.StrictMode>
+   <App />
+   // </React.StrictMode>
 )


### PR DESCRIPTION
- [feat: add undo-redo feature using event](https://github.com/Ashish-simpleCoder/react-ts-drawing-app/commit/f16d62dc5be41ebc8ee3056bd489a6153fc04bf8)
- [refactor: move path histories state in canvas-atom](https://github.com/Ashish-simpleCoder/react-ts-drawing-app/commit/b595f95232f6340276e883e4ac0c5b205fb8da3b)